### PR TITLE
A0-2803: Add pallets APIs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use subxt::ext::sp_core::{crypto::AccountId32, sr25519, H256};
 
 pub mod connection;
 mod key_pair;
+pub mod pallets;
 
 pub use key_pair::*;
 
@@ -17,8 +18,12 @@ pub type AccountId = AccountId32;
 pub type CodeHash = H256;
 /// An alias for a block hash type.
 pub type BlockHash = H256;
+/// An alias for a block number type.
+pub type BlockNumber = u32;
 /// An alias for a transaction hash type.
 pub type TxHash = H256;
+/// An alias for the amount of tokens.
+pub type Balance = u128;
 
 /// When submitting a transaction, wait for given status before proceeding.
 #[derive(Copy, Clone)]
@@ -29,4 +34,15 @@ pub enum TxStatus {
     Finalized,
     /// A tx must be successfully submitted.
     Submitted,
+}
+
+/// Weight of a transaction.
+#[derive(Clone, Debug, Eq, PartialEq, codec::Decode, codec::Encode)]
+pub struct Weight {
+    /// Execution time coordinate.
+    #[codec(compact)]
+    pub ref_time: u64,
+    /// Proof size coordinate.
+    #[codec(compact)]
+    pub proof_size: u64,
 }

--- a/src/pallets/author.rs
+++ b/src/pallets/author.rs
@@ -1,0 +1,9 @@
+/// Implements RPC calls for  [`author`](https://paritytech.github.io/substrate/master/sc_rpc/author/struct.Author.html) pallet.
+#[async_trait::async_trait]
+pub trait AuthorRpc {
+    /// Session keys type.
+    type SessionKeys;
+
+    /// API for [`rotate_keys`](https://paritytech.github.io/substrate/master/sc_rpc/author/struct.Author.html#method.rotate_keys) call.
+    async fn author_rotate_keys(&self) -> anyhow::Result<Self::SessionKeys>;
+}

--- a/src/pallets/balances.rs
+++ b/src/pallets/balances.rs
@@ -1,0 +1,87 @@
+use crate::{connection::TxInfo, AccountId, Balance, BlockHash, TxStatus};
+
+/// Pallet balances read-only API.
+#[async_trait::async_trait]
+pub trait BalanceApi {
+    /// The type of balance lock.
+    type BalanceLock: Send;
+
+    /// API for [`locks`](https://paritytech.github.io/substrate/master/pallet_balances/pallet/struct.Pallet.html#method.locks) call.
+    /// * `account` - an account to query locked balance for
+    /// * `at` - optional hash of a block to query state from
+    async fn locks_for_account(
+        &self,
+        account: AccountId,
+        at: Option<BlockHash>,
+    ) -> Vec<Self::BalanceLock>;
+
+    /// API for [`locks`](https://paritytech.github.io/substrate/master/pallet_balances/pallet/struct.Pallet.html#method.locks) call.
+    /// * `accounts` - a list of accounts to query locked balance for
+    /// * `at` - optional hash of a block to query state from
+    ///
+    /// By default, this calls `locks_for_account` for each account in `accounts`.
+    async fn locks(
+        &self,
+        accounts: &[AccountId],
+        at: Option<BlockHash>,
+    ) -> Vec<Vec<Self::BalanceLock>> {
+        let mut locks = vec![];
+        for account in accounts {
+            locks.push(self.locks_for_account(account.clone(), at).await);
+        }
+        locks
+    }
+
+    /// Returns [`total_issuance`](https://paritytech.github.io/substrate/master/pallet_balances/pallet/type.TotalIssuance.html).
+    async fn total_issuance(&self, at: Option<BlockHash>) -> Balance;
+
+    /// Returns [`existential_deposit`](https://paritytech.github.io/substrate/master/pallet_balances/index.html#terminology).
+    async fn existential_deposit(&self) -> anyhow::Result<Balance>;
+}
+
+/// Pallet balances API
+#[async_trait::async_trait]
+pub trait BalanceUserApi {
+    /// API for [`transfer`](https://paritytech.github.io/substrate/master/pallet_balances/pallet/struct.Pallet.html#method.transfer) call.
+    async fn transfer(
+        &self,
+        dest: AccountId,
+        amount: Balance,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`transfer`](https://paritytech.github.io/substrate/master/pallet_balances/pallet/struct.Pallet.html#method.transfer) call.
+    /// Include tip in the tx.
+    async fn transfer_with_tip(
+        &self,
+        dest: AccountId,
+        amount: Balance,
+        tip: Balance,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+}
+
+/// Pallet balances logic not directly related to any pallet call.
+#[async_trait::async_trait]
+pub trait BalanceUserBatchExtApi {
+    /// Performs batch of `balances.transfer` calls.
+    /// * `dest` - a list of accounts to send tokens to
+    /// * `amount` - an amount to transfer
+    /// * `status` - a [`TxStatus`] for a tx to wait for
+    ///
+    /// # Examples
+    /// ```ignore
+    ///  for chunk in stash_accounts.chunks(1024) {
+    ///         connection
+    ///             .batch_transfer(chunk, 1_000_000_000_000u128, TxStatus::InBlock)
+    ///             .await
+    ///             .unwrap();
+    ///     }
+    /// ```
+    async fn batch_transfer(
+        &self,
+        dest: &[AccountId],
+        amount: Balance,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+}

--- a/src/pallets/contract.rs
+++ b/src/pallets/contract.rs
@@ -1,0 +1,105 @@
+use codec::Compact;
+
+use crate::{connection::TxInfo, AccountId, Balance, BlockHash, CodeHash, TxStatus, Weight};
+
+/// Arguments to [`ContractRpc::call_and_get`].
+#[derive(codec::Encode)]
+pub struct ContractCallArgs {
+    /// Who is singing a tx.
+    pub origin: AccountId,
+    /// Address of the contract to call.
+    pub dest: AccountId,
+    /// The balance to transfer from the `origin` to `dest`.
+    pub value: Balance,
+    /// The gas limit enforced when executing the constructor.
+    pub gas_limit: Option<Weight>,
+    /// The maximum amount of balance that can be charged from the caller to pay for the storage consumed.
+    pub storage_deposit_limit: Option<Balance>,
+    /// The input data to pass to the contract.
+    pub input_data: Vec<u8>,
+}
+
+/// Pallet contracts read-only api.
+#[async_trait::async_trait]
+pub trait ContractsApi {
+    /// Information about a contract owner.
+    type OwnerInfo;
+
+    /// Returns `contracts.owner_info_of` storage for a given code hash.
+    /// * `code_hash` - a code hash
+    /// * `at` - optional hash of a block to query state from
+    async fn get_owner_info(
+        &self,
+        code_hash: CodeHash,
+        at: Option<BlockHash>,
+    ) -> Option<Self::OwnerInfo>;
+}
+
+/// Pallet contracts api.
+#[async_trait::async_trait]
+pub trait ContractsUserApi {
+    /// The type of determinism to use when instantiating a contract.
+    type Determinism;
+
+    /// API for [`upload_code`](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/struct.Pallet.html#method.upload_code) call.
+    async fn upload_code(
+        &self,
+        code: Vec<u8>,
+        storage_limit: Option<Compact<Balance>>,
+        determinism: Self::Determinism,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`instantiate`](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/struct.Pallet.html#method.instantiate) call.
+    #[allow(clippy::too_many_arguments)]
+    async fn instantiate(
+        &self,
+        code_hash: CodeHash,
+        balance: Balance,
+        gas_limit: Weight,
+        storage_limit: Option<Compact<Balance>>,
+        data: Vec<u8>,
+        salt: Vec<u8>,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`instantiate_with_code`](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/struct.Pallet.html#method.instantiate_with_code) call.
+    #[allow(clippy::too_many_arguments)]
+    async fn instantiate_with_code(
+        &self,
+        code: Vec<u8>,
+        balance: Balance,
+        gas_limit: Weight,
+        storage_limit: Option<Compact<Balance>>,
+        data: Vec<u8>,
+        salt: Vec<u8>,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`call`](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/struct.Pallet.html#method.call) call.
+    async fn call(
+        &self,
+        destination: AccountId,
+        balance: Balance,
+        gas_limit: Weight,
+        storage_limit: Option<Compact<Balance>>,
+        data: Vec<u8>,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`remove_code`](https://paritytech.github.io/substrate/master/pallet_contracts/pallet/struct.Pallet.html#method.remove_code) call.
+    async fn remove_code(&self, code_hash: BlockHash, status: TxStatus) -> anyhow::Result<TxInfo>;
+}
+
+/// RPC for runtime ContractsApi
+#[async_trait::async_trait]
+pub trait ContractRpc {
+    /// The type returned from [`call_and_get`](https://paritytech.github.io/substrate/master/pallet_contracts/trait.ContractsApi.html#method.call).
+    type ContractExecResult: Send;
+
+    /// API for [`call`](https://paritytech.github.io/substrate/master/pallet_contracts/trait.ContractsApi.html#method.call) call.
+    async fn call_and_get(
+        &self,
+        args: ContractCallArgs,
+    ) -> anyhow::Result<Self::ContractExecResult>;
+}

--- a/src/pallets/mod.rs
+++ b/src/pallets/mod.rs
@@ -1,0 +1,24 @@
+//! Convenient APIs of the common pallets.
+
+/// Pallet author API
+pub mod author;
+/// Pallet balances API
+pub mod balances;
+/// Pallet contracts API
+pub mod contract;
+/// Pallet multisig API
+pub mod multisig;
+/// Pallet session API
+pub mod session;
+/// Pallet staking API
+pub mod staking;
+/// Pallet system API
+pub mod system;
+/// Pallet transaction payment API
+pub mod transaction_payment;
+/// Pallet treasury API
+pub mod treasury;
+/// Pallet utility API
+pub mod utility;
+/// Pallet vesting API
+pub mod vesting;

--- a/src/pallets/multisig.rs
+++ b/src/pallets/multisig.rs
@@ -1,0 +1,62 @@
+use crate::{connection::TxInfo, AccountId, BlockNumber, TxStatus, Weight};
+
+/// An alias for a call hash.
+pub type CallHash = [u8; 32];
+/// An alias for a threshold.
+pub type MultisigThreshold = u16;
+
+/// Struct describing coordinates of a multisig aggregation.
+#[derive(Clone, Debug, Eq, PartialEq, codec::Decode, codec::Encode)]
+pub struct Timepoint {
+    /// Index of a block.
+    pub height: BlockNumber,
+    /// Index of a call in a block.
+    pub index: BlockNumber,
+}
+
+/// Pallet multisig api.
+#[async_trait::async_trait]
+pub trait MultisigUserApi {
+    /// Runtime call API.
+    type Call;
+
+    /// API for [`as_multi_threshold_1`](https://paritytech.github.io/substrate/master/pallet_multisig/pallet/struct.Pallet.html#method.as_multi_threshold_1) call.
+    async fn as_multi_threshold_1(
+        &self,
+        other_signatories: Vec<AccountId>,
+        call: Self::Call,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`as_multi`](https://paritytech.github.io/substrate/master/pallet_multisig/pallet/struct.Pallet.html#method.as_multi) call.
+    async fn as_multi(
+        &self,
+        threshold: MultisigThreshold,
+        other_signatories: Vec<AccountId>,
+        timepoint: Option<Timepoint>,
+        max_weight: Weight,
+        call: Self::Call,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`approve_as_multi`](https://paritytech.github.io/substrate/master/pallet_multisig/pallet/struct.Pallet.html#method.approve_as_multi) call.
+    async fn approve_as_multi(
+        &self,
+        threshold: MultisigThreshold,
+        other_signatories: Vec<AccountId>,
+        timepoint: Option<Timepoint>,
+        max_weight: Weight,
+        call_hash: CallHash,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`cancel_as_multi`](https://paritytech.github.io/substrate/master/pallet_multisig/pallet/struct.Pallet.html#method.cancel_as_multi) call.
+    async fn cancel_as_multi(
+        &self,
+        threshold: MultisigThreshold,
+        other_signatories: Vec<AccountId>,
+        timepoint: Timepoint,
+        call_hash: CallHash,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+}

--- a/src/pallets/session.rs
+++ b/src/pallets/session.rs
@@ -1,0 +1,37 @@
+use crate::{connection::TxInfo, AccountId, BlockHash, TxStatus};
+
+/// Pallet session read-only api.
+#[async_trait::async_trait]
+pub trait SessionApi {
+    /// Session keys type.
+    type SessionKeys;
+    /// Session index type.
+    type SessionIndex;
+
+    /// API for [`next_keys`](https://paritytech.github.io/substrate/master/pallet_session/pallet/type.NextKeys.html) call.
+    async fn get_next_session_keys(
+        &self,
+        account: AccountId,
+        at: Option<BlockHash>,
+    ) -> Option<Self::SessionKeys>;
+
+    /// API for [`current_index`](https://paritytech.github.io/substrate/master/pallet_session/pallet/struct.Pallet.html#method.current_index) call.
+    async fn get_session(&self, at: Option<BlockHash>) -> Self::SessionIndex;
+
+    /// API for [`validators`](https://paritytech.github.io/substrate/master/pallet_session/pallet/struct.Pallet.html#method.validators) call.
+    async fn get_validators(&self, at: Option<BlockHash>) -> Vec<AccountId>;
+}
+
+/// Pallet session API.
+#[async_trait::async_trait]
+pub trait SessionUserApi {
+    /// Session keys type.
+    type SessionKeys;
+
+    /// API for [`set_keys`](https://paritytech.github.io/substrate/master/pallet_session/pallet/struct.Pallet.html#method.set_keys) call.
+    async fn set_keys(
+        &self,
+        new_keys: Self::SessionKeys,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+}

--- a/src/pallets/staking.rs
+++ b/src/pallets/staking.rs
@@ -1,0 +1,235 @@
+use subxt::storage::StorageKey;
+
+use crate::{connection::TxInfo, AccountId, Balance, BlockHash, TxStatus};
+
+/// Any object that implemnts pallet staking read-only api.
+#[async_trait::async_trait]
+pub trait StakingApi {
+    /// Staking era index type.
+    type EraIndex;
+    /// Staking ledger type.
+    type StakingLedger;
+    /// Staking exposure type.
+    type Exposure;
+    /// Staking reward points type.
+    type EraRewardPoints;
+
+    /// Returns [`active_era`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.active_era).
+    /// * `at` - optional hash of a block to query state from
+    async fn get_active_era(&self, at: Option<BlockHash>) -> Self::EraIndex;
+
+    /// Returns [`current_era`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.current_era).
+    /// * `at` - optional hash of a block to query state from
+    async fn get_current_era(&self, at: Option<BlockHash>) -> Self::EraIndex;
+
+    /// Returns [`bonded`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.bonded) for a given stash account.
+    /// * `stash` - a stash account id
+    /// * `at` - optional hash of a block to query state from
+    async fn get_bonded(&self, stash: AccountId, at: Option<BlockHash>) -> Option<AccountId>;
+
+    /// Returns [`ledger`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.ledger) for a given controller account.
+    /// * `controller` - a controller account id
+    /// * `at` - optional hash of a block to query state from
+    async fn get_ledger(&self, controller: AccountId, at: Option<BlockHash>)
+        -> Self::StakingLedger;
+
+    /// Returns [`eras_validator_reward`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.eras_validator_reward) for a given era.
+    /// * `era` - an era index
+    /// * `at` - optional hash of a block to query state from
+    async fn get_payout_for_era(&self, era: Self::EraIndex, at: Option<BlockHash>) -> Balance;
+
+    /// Returns [`eras_stakers`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.eras_stakers) for a given era and account id.
+    /// * `era` - an era index
+    /// * `account_id` - an account id
+    /// * `at` - optional hash of a block to query state from
+    async fn get_exposure(
+        &self,
+        era: Self::EraIndex,
+        account_id: &AccountId,
+        at: Option<BlockHash>,
+    ) -> Self::Exposure;
+
+    /// Returns [`eras_reward_points`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.eras_reward_points) for a given era.
+    /// * `era` - an era index
+    /// * `at` - optional hash of a block to query state from
+    async fn get_era_reward_points(
+        &self,
+        era: Self::EraIndex,
+        at: Option<BlockHash>,
+    ) -> Option<Self::EraRewardPoints>;
+
+    /// Returns [`minimum_validator_count`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.minimum_validator_count).
+    /// * `at` - optional hash of a block to query state from
+    async fn get_minimum_validator_count(&self, at: Option<BlockHash>) -> u32;
+
+    /// Returns [`SessionsPerEra`](https://paritytech.github.io/substrate/master/pallet_staking/trait.Config.html#associatedtype.SessionsPerEra) const.
+    async fn get_session_per_era(&self) -> anyhow::Result<u32>;
+}
+
+/// Pallet staking api
+#[async_trait::async_trait]
+pub trait StakingUserApi {
+    /// Staking era index type.
+    type EraIndex;
+
+    /// API for [`bond`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.bond) call.
+    async fn bond(
+        &self,
+        initial_stake: Balance,
+        controller_id: AccountId,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`validate`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.validate) call.
+    async fn validate(
+        &self,
+        validator_commission_percentage: u8,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`payout_stakers`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.payout_stakers) call.
+    async fn payout_stakers(
+        &self,
+        stash_account: AccountId,
+        era: Self::EraIndex,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`nominate`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.nominate) call.
+    async fn nominate(
+        &self,
+        nominee_account_id: AccountId,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`chill`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.chill) call.
+    async fn chill(&self, status: TxStatus) -> anyhow::Result<TxInfo>;
+
+    /// API for [`bond_extra`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.bond_extra) call.
+    async fn bond_extra_stake(
+        &self,
+        extra_stake: Balance,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+}
+
+/// Pallet staking logic, not directly related to any particular pallet call.
+#[async_trait::async_trait]
+pub trait StakingApiExt {
+    /// Send batch of [`bond`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.bond) calls.
+    /// * `accounts` - a slice of account ids pairs (stash, controller)
+    /// * `stake` - what amount should be bonded,
+    /// * `status` - a [`TxStatus`] of a tx to wait for
+    ///
+    /// # Examples
+    /// ```ignore
+    /// async fn nominate_validator(
+    ///     connection: &RootConnection,
+    ///     nominator_controller_accounts: Vec<AccountId>,
+    ///     nominator_stash_accounts: Vec<AccountId>,
+    ///     nominee_account: AccountId,
+    /// ) {
+    ///     let stash_controller_accounts = nominator_stash_accounts
+    ///         .iter()
+    ///         .cloned()
+    ///         .zip(nominator_controller_accounts.iter().cloned())
+    ///         .collect::<Vec<_>>();
+    ///
+    ///     let mut rng = thread_rng();
+    ///     for chunk in stash_controller_accounts
+    ///         .chunks(256)
+    ///         .map(|c| c.to_vec())
+    ///     {
+    ///         let stake = 100 * 1_000_000_000_000u128;
+    ///         connection
+    ///             .batch_bond(&chunk, stake, TxStatus::Submitted)
+    ///             .await
+    ///             .unwrap();
+    ///     }
+    ///     let nominator_nominee_accounts = nominator_controller_accounts
+    ///        .iter()
+    ///        .cloned()
+    ///        .zip(iter::repeat(&nominee_account).cloned())
+    ///        .collect::<Vec<_>>();
+    ///     for chunks in nominator_nominee_accounts.chunks(128) {
+    ///        connection
+    ///            .batch_nominate(chunks, TxStatus::InBlock)
+    ///            .await
+    ///            .unwrap();
+    ///    }
+    /// }
+    /// ```
+    async fn batch_bond(
+        &self,
+        accounts: &[(AccountId, AccountId)],
+        stake: Balance,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// Send batch of [`nominate`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.nominate) calls.
+    /// * `nominator_nominee_pairs` - a slice of account ids pairs (nominator, nominee)
+    /// * `status` - a [`TxStatus`] of a tx to wait for
+    ///
+    /// # Examples
+    /// see [`Self::batch_bond`] example above
+    async fn batch_nominate(
+        &self,
+        nominator_nominee_pairs: &[(AccountId, AccountId)],
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+}
+
+/// Pallet staking api that requires sudo.
+#[async_trait::async_trait]
+pub trait StakingSudoApi {
+    /// API for [`force_new_era`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.force_new_era) call.
+    async fn force_new_era(&self, status: TxStatus) -> anyhow::Result<TxInfo>;
+
+    /// API for [`set_staking_config`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.set_staking_configs) call.
+    async fn set_staking_config(
+        &self,
+        minimal_nominator_bond: Option<Balance>,
+        minimal_validator_bond: Option<Balance>,
+        max_nominators_count: Option<u32>,
+        max_validators_count: Option<u32>,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+}
+
+/// Logic for retrieving raw storage keys or values from a pallet staking.
+#[async_trait::async_trait]
+pub trait StakingRawApi {
+    /// Staking era index type.
+    type EraIndex;
+
+    /// Returns all encoded [`eras_stakers`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.eras_stakers).
+    /// storage keys for a given era
+    /// * `era` - an era index
+    /// * `at` - optional hash of a block to query state from
+    ///
+    /// # Examples
+    /// ```ignore
+    /// let stakers = connection
+    ///         .get_stakers_storage_keys(current_era, None)
+    ///         .await
+    ///         .into_iter()
+    ///         .map(|key| key.0);
+    /// ```
+    async fn get_stakers_storage_keys(
+        &self,
+        era: Self::EraIndex,
+        at: Option<BlockHash>,
+    ) -> anyhow::Result<Vec<StorageKey>>;
+
+    /// Returns encoded [`eras_stakers`](https://paritytech.github.io/substrate/master/pallet_staking/struct.Pallet.html#method.eras_stakers).
+    /// storage keys for a given era and given account ids
+    /// * `era` - an era index
+    /// * `accounts` - list of account ids
+    /// * `at` - optional hash of a block to query state from
+    async fn get_stakers_storage_keys_from_accounts(
+        &self,
+        era: Self::EraIndex,
+        accounts: &[AccountId],
+        at: Option<BlockHash>,
+    ) -> Vec<StorageKey>;
+}

--- a/src/pallets/system.rs
+++ b/src/pallets/system.rs
@@ -1,0 +1,17 @@
+use crate::{connection::TxInfo, AccountId, Balance, BlockHash, TxStatus};
+
+/// Pallet system read-only api.
+#[async_trait::async_trait]
+pub trait SystemApi {
+    /// returns free balance of a given account
+    /// * `account` - account id
+    /// * `at` - optional hash of a block to query state from
+    async fn get_free_balance(&self, account: AccountId, at: Option<BlockHash>) -> Balance;
+}
+
+/// Pallet system api.
+#[async_trait::async_trait]
+pub trait SystemSudoApi {
+    /// API for [`set_code`](https://paritytech.github.io/substrate/master/frame_system/pallet/struct.Pallet.html#method.set_code) call.
+    async fn set_code(&self, code: Vec<u8>, status: TxStatus) -> anyhow::Result<TxInfo>;
+}

--- a/src/pallets/transaction_payment.rs
+++ b/src/pallets/transaction_payment.rs
@@ -1,0 +1,10 @@
+use subxt::ext::sp_runtime::FixedU128;
+
+use crate::BlockHash;
+
+/// Transaction payment pallet API.
+#[async_trait::async_trait]
+pub trait TransactionPaymentApi {
+    /// API for [`next_fee_multiplier`](https://paritytech.github.io/substrate/master/pallet_transaction_payment/pallet/struct.Pallet.html#method.next_fee_multiplier) call.
+    async fn get_next_fee_multiplier(&self, at: Option<BlockHash>) -> FixedU128;
+}

--- a/src/pallets/treasury.rs
+++ b/src/pallets/treasury.rs
@@ -1,0 +1,41 @@
+use crate::{connection::TxInfo, AccountId, Balance, BlockHash, TxStatus};
+
+/// Pallet treasury read-only api.
+#[async_trait::async_trait]
+pub trait TreasuryApi {
+    /// Returns an unique account id for all treasury transfers.
+    async fn treasury_account(&self) -> AccountId;
+
+    /// Returns storage `proposals_count`.
+    /// * `at` - an optional block hash to query state from
+    async fn proposals_count(&self, at: Option<BlockHash>) -> Option<u32>;
+
+    /// Returns storage `approvals`.
+    /// * `at` - an optional block hash to query state from
+    async fn approvals(&self, at: Option<BlockHash>) -> Vec<u32>;
+}
+
+/// Pallet treasury api.
+#[async_trait::async_trait]
+pub trait TreasuryUserApi {
+    /// API for [`propose_spend`](https://paritytech.github.io/substrate/master/pallet_treasury/pallet/struct.Pallet.html#method.propose_spend) call.
+    async fn propose_spend(
+        &self,
+        amount: Balance,
+        beneficiary: AccountId,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`approve_proposal`](https://paritytech.github.io/substrate/master/pallet_treasury/pallet/struct.Pallet.html#method.approve_proposal) call.
+    async fn approve(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxInfo>;
+
+    /// API for [`reject_proposal`](https://paritytech.github.io/substrate/master/pallet_treasury/pallet/struct.Pallet.html#method.reject_proposal) call.
+    async fn reject(&self, proposal_id: u32, status: TxStatus) -> anyhow::Result<TxInfo>;
+}
+
+/// Pallet treasury functionality that is not directly related to any pallet call.
+#[async_trait::async_trait]
+pub trait TreasureApiExt {
+    /// When `staking.payout_stakers` is done, what amount of AZERO is transferred to the treasury.
+    async fn possible_treasury_payout(&self) -> anyhow::Result<Balance>;
+}

--- a/src/pallets/utility.rs
+++ b/src/pallets/utility.rs
@@ -1,0 +1,11 @@
+use crate::{connection::TxInfo, TxStatus};
+
+/// Pallet utility api.
+#[async_trait::async_trait]
+pub trait UtilityApi {
+    /// Runtime call API.
+    type Call;
+
+    /// API for [`batch`](https://paritytech.github.io/substrate/master/pallet_utility/pallet/struct.Pallet.html#method.batch) call.
+    async fn batch_call(&self, calls: Vec<Self::Call>, status: TxStatus) -> anyhow::Result<TxInfo>;
+}

--- a/src/pallets/vesting.rs
+++ b/src/pallets/vesting.rs
@@ -1,0 +1,42 @@
+use crate::{connection::TxInfo, AccountId, BlockHash, TxStatus};
+
+/// Read only pallet vesting API.
+#[async_trait::async_trait]
+pub trait VestingApi {
+    /// Information about the vesting schedule.
+    type VestingInfo;
+
+    /// Returns [`VestingInfo`] of the given account.
+    /// * `who` - an account id
+    /// * `at` - optional hash of a block to query state from
+    async fn get_vesting(&self, who: AccountId, at: Option<BlockHash>) -> Vec<Self::VestingInfo>;
+}
+
+/// Pallet vesting api.
+#[async_trait::async_trait]
+pub trait VestingUserApi {
+    /// Information about the vesting schedule.
+    type VestingInfo;
+
+    /// API for [`vest`](https://paritytech.github.io/substrate/master/pallet_vesting/pallet/enum.Call.html#variant.vest) call.
+    async fn vest(&self, status: TxStatus) -> anyhow::Result<TxInfo>;
+
+    /// API for [`vest_other`](https://paritytech.github.io/substrate/master/pallet_vesting/pallet/enum.Call.html#variant.vest_other) call.
+    async fn vest_other(&self, status: TxStatus, other: AccountId) -> anyhow::Result<TxInfo>;
+
+    /// API for [`vested_transfer`](https://paritytech.github.io/substrate/master/pallet_vesting/pallet/enum.Call.html#variant.vested_transfer) call.
+    async fn vested_transfer(
+        &self,
+        receiver: AccountId,
+        schedule: Self::VestingInfo,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+
+    /// API for [`merge_schedules`](https://paritytech.github.io/substrate/master/pallet_vesting/pallet/enum.Call.html#variant.merge_schedules) call.
+    async fn merge_schedules(
+        &self,
+        idx1: u32,
+        idx2: u32,
+        status: TxStatus,
+    ) -> anyhow::Result<TxInfo>;
+}


### PR DESCRIPTION
We bring Substrate pallet APIs from `aleph-client`. Few notes:
 - implementations will be done in another PR (they must be opt-in)
 - aleph-specific pallets (`aleph`, `committee-management`, `elections`, `baby-liminal`) will stay in `aleph-client`)
 - since we can't (really, really don't want to) depend here on any pallet crate, we had to abstract some pallet-specific types up to trait level (associated types)
 - multisig contextual API will be brought in another PR